### PR TITLE
Fix Text Color to Meet WCAG 2.0 Contrast Minimum

### DIFF
--- a/src/components/Thread/Thread.vue
+++ b/src/components/Thread/Thread.vue
@@ -675,12 +675,10 @@ export default {
             try {
                 let colorString;
 
-                if (message.type == 1) { // Message was sent by the user, use default color
+                if (message.type == 1) // Message was sent by the user, use default color
                     colorString = this.color;
-                }
-                else {
+                else
                     colorString = this.getColor(message);
-                }
 
                 if (!colorString)
                     colorString = this.color;

--- a/src/components/Thread/Thread.vue
+++ b/src/components/Thread/Thread.vue
@@ -674,10 +674,13 @@ export default {
         text_color (message) {
             try {
                 let colorString;
-                if (message.message_from)
-                    colorString = this.getColor(message);
-                else // Otherwise default color
+
+                if (message.type == 1) { // Message was sent by the user, use default color
                     colorString = this.color;
+                }
+                else {
+                    colorString = this.getColor(message);
+                }
 
                 if (!colorString)
                     colorString = this.color;

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -209,21 +209,31 @@ export default class Util {
         firebase.initializeApp(config);
     }
 
+    // Set text color to meet WCAG 2.0 Success Criterion 1.4.3
+    // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#visual-audio-contrast-contrast
     static getTextColorBasedOnBackground(color) {
         let colorString = color.replace("rgba(", "").replace(")", "");
         colorString = colorString.replace("rgb(", "").replace(")", "");
 
-        // Get actual colors
+        // Get actual colors in sRGB
         const  colorArray = colorString.split(",");
-        const  red = colorArray[0];
-        const  green = colorArray[1];
-        const  blue = colorArray[2];
+        const  red = this.getSRGB(colorArray[0]);
+        const  green = this.getSRGB(colorArray[1]);
+        const  blue = this.getSRGB(colorArray[2]);
 
-        // Some magic with implicit type conversion
-        const  darkness = 1 - (0.299 * red + 0.587 * green + 0.114 * blue) / 255;
+        // Compute the relative luminance of the background color
+        // https://www.w3.org/TR/WCAG20/#relativeluminancedef
+        const  luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue;
 
-        // Determine color
-        return darkness >= 0.30 ? "#fff" : "#000";
+        // Determine color based on the contrast ratio 4.5:1
+        // https://www.w3.org/TR/WCAG20/#contrast-ratiodef
+        return luminance < 0.233 ? "#fff" : "#000";
+    }
+
+    static getSRGB(component) {
+        component = component / 255;
+        component = (component <= 0.03928) ? component / 12.92 : Math.pow(((component + 0.055) / 1.055), 2.4);
+        return component;
     }
 }
 


### PR DESCRIPTION
Currently the text color is not possible to see for some colors and themes.

For example, when the color is too bright, the text will appear white and it is very hard to read.
![image](https://user-images.githubusercontent.com/38381547/74764969-537c4f00-5248-11ea-8373-cdc3c59ab8b1.png)

This change sets the project to follow the [WCAG 2.0 Contrast Minimum](https://www.w3.org/TR/2008/REC-WCAG20-20081211/#visual-audio-contrast-contrast) when setting text colors.

The same color now sets the text to be black.
![image](https://user-images.githubusercontent.com/38381547/74765063-832b5700-5248-11ea-9383-4c7d0942d689.png)

I have followed the guideline recommendation of setting the ratio to be 4.5:1.
