### PR TITLE
Update snippet from websocket stream

### DIFF
--- a/src/components/Conversations/Conversations.vue
+++ b/src/components/Conversations/Conversations.vue
@@ -127,6 +127,7 @@ export default {
     mounted () {
         this.$store.state.msgbus.$on('newMessage', this.updateConversation);
         this.$store.state.msgbus.$on('conversationRead', this.updateRead);
+        this.$store.state.msgbus.$on('conversationSnippetUpdated', this.updateSnippet);
         this.$store.state.msgbus.$on('removedConversation', this.fetchConversations);
         this.$store.state.msgbus.$on('refresh-btn', this.refresh);
         this.$store.state.msgbus.$on('search-btn', this.toggleSearch);
@@ -157,6 +158,7 @@ export default {
     beforeDestroy () {
         this.$store.state.msgbus.$off('newMessage', this.updateConversation);
         this.$store.state.msgbus.$off('conversationRead', this.updateRead);
+        this.$store.state.msgbus.$off('conversationSnippetUpdated', this.updateSnippet);
         this.$store.state.msgbus.$off('removedConversation', this.fetchConversations);
         this.$store.state.msgbus.$off('refresh-btn', this.refresh);
         this.$store.state.msgbus.$off('search-btn', this.toggleSearch);
@@ -354,6 +356,15 @@ export default {
                 this.$store.commit('decrement_unread_count');
 
             conv.read = true;
+            conv.hash = Hash(conv);
+        },
+
+        updateSnippet (id, snippet) {
+            let { conv, conv_index } = this.getConversation(id);
+            if(!conv || !conv_index)
+                return false;
+
+            conv.snippet = snippet;
             conv.hash = Hash(conv);
         },
 

--- a/src/components/Conversations/Conversations.vue
+++ b/src/components/Conversations/Conversations.vue
@@ -364,7 +364,7 @@ export default {
             if(!conv || !conv_index)
                 return false;
 
-            conv.snippet = snippet;
+            conv.snippet = joypixels.toImage(snippet);
             conv.hash = Hash(conv);
         },
 

--- a/src/utils/api/stream.js
+++ b/src/utils/api/stream.js
@@ -120,11 +120,13 @@ export default class Stream {
             const id = json.message.content.id;
             const snippet = Crypto.decrypt(json.message.content.snippet);
 
-            SessionCache.updateConversationSnippet(id, snippet, 'index_public_unarchived');
-            SessionCache.updateConversationSnippet(id, snippet, 'index_archived');
-            SessionCache.updateConversationSnippet(id, snippet, 'index_private');
-
-            store.state.msgbus.$emit('conversationSnippetUpdated', id, snippet);
+            if (snippet) {
+                SessionCache.updateConversationSnippet(id, snippet, 'index_public_unarchived');
+                SessionCache.updateConversationSnippet(id, snippet, 'index_archived');
+                SessionCache.updateConversationSnippet(id, snippet, 'index_private');
+    
+                store.state.msgbus.$emit('conversationSnippetUpdated', id, snippet);
+            }
         } else if (operation == "update_message_type") {
             const id = json.message.content.id;
             const message_type = json.message.content.message_type;

--- a/src/utils/api/stream.js
+++ b/src/utils/api/stream.js
@@ -112,10 +112,19 @@ export default class Stream {
         } else if (operation == "read_conversation") {
             const id = json.message.content.id;
 
-            SessionCache.readConversation('index_public_unarchived');
-            SessionCache.readConversation('index_archived');
+            SessionCache.readConversation(id, 'index_public_unarchived');
+            SessionCache.readConversation(id, 'index_archived');
 
             store.state.msgbus.$emit('conversationRead', id);
+        } else if (operation == "updated_conversation") {
+            const id = json.message.content.id;
+            const snippet = Crypto.decrypt(json.message.content.snippet);
+
+            SessionCache.updateConversationSnippet(id, snippet, 'index_public_unarchived');
+            SessionCache.updateConversationSnippet(id, snippet, 'index_archived');
+            SessionCache.updateConversationSnippet(id, snippet, 'index_private');
+
+            store.state.msgbus.$emit('conversationSnippetUpdated', id, snippet);
         } else if (operation == "update_message_type") {
             const id = json.message.content.id;
             const message_type = json.message.content.message_type;

--- a/src/utils/cache_manager.js
+++ b/src/utils/cache_manager.js
@@ -200,6 +200,7 @@ export default class SessionCache {
             for (let i = 0; i < conversations.length; i++) {
                 if (conversations[i].device_id == message.conversation_id) {
                     conversations[i].timestamp = message.timestamp;
+                    conversations[i].snippet = message.mime_type.indexOf("text") > -1 ? message.data : "";
                     this.putConversations(this.resortConversations(conversations), 'index_public_unarchived');
                     return;
                 }
@@ -211,6 +212,7 @@ export default class SessionCache {
             for (let i = 0; i < conversations.length; i++) {
                 if (conversations[i].device_id == message.conversation_id) {
                     conversations[i].timestamp = message.timestamp;
+                    conversations[i].snippet = message.mime_type.indexOf("text") > -1 ? message.data : "";
                     this.putConversations(this.resortConversations(conversations), 'index_archived');
                     return;
                 }
@@ -222,6 +224,7 @@ export default class SessionCache {
             for (let i = 0; i < conversations.length; i++) {
                 if (conversations[i].device_id == message.conversation_id) {
                     conversations[i].timestamp = message.timestamp;
+                    conversations[i].snippet = message.mime_type.indexOf("text") > -1 ? message.data : "";
                     this.putConversations(this.resortConversations(conversations), 'index_private');
                     return;
                 }

--- a/src/utils/cache_manager.js
+++ b/src/utils/cache_manager.js
@@ -147,6 +147,22 @@ export default class SessionCache {
         SessionCache.putConversations(conversations, index);
     }
 
+    static updateConversationSnippet (conversation_id, snippet, index = 'index_public_unarchived') {
+        if (!SessionCache.hasConversations(index)) {
+            return;
+        }
+
+        let conversations = SessionCache.getConversations(index);
+        for (let i = 0; i < conversations.length; i++) {
+            if (conversations[i].device_id == conversation_id) {
+                conversations[i].snippet = snippet;
+                break;
+            }
+        }
+
+        SessionCache.putConversations(conversations, index);
+    }
+
     static cacheMessage (message) {
         if (!SessionCache.hasMessages(message.conversation_id)) {
             return;

--- a/src/utils/cache_manager.js
+++ b/src/utils/cache_manager.js
@@ -200,7 +200,6 @@ export default class SessionCache {
             for (let i = 0; i < conversations.length; i++) {
                 if (conversations[i].device_id == message.conversation_id) {
                     conversations[i].timestamp = message.timestamp;
-                    conversations[i].snippet = message.mime_type.indexOf("text") > -1 ? message.data : "";
                     this.putConversations(this.resortConversations(conversations), 'index_public_unarchived');
                     return;
                 }
@@ -212,7 +211,6 @@ export default class SessionCache {
             for (let i = 0; i < conversations.length; i++) {
                 if (conversations[i].device_id == message.conversation_id) {
                     conversations[i].timestamp = message.timestamp;
-                    conversations[i].snippet = message.mime_type.indexOf("text") > -1 ? message.data : "";
                     this.putConversations(this.resortConversations(conversations), 'index_archived');
                     return;
                 }
@@ -224,7 +222,6 @@ export default class SessionCache {
             for (let i = 0; i < conversations.length; i++) {
                 if (conversations[i].device_id == message.conversation_id) {
                     conversations[i].timestamp = message.timestamp;
-                    conversations[i].snippet = message.mime_type.indexOf("text") > -1 ? message.data : "";
                     this.putConversations(this.resortConversations(conversations), 'index_private');
                     return;
                 }


### PR DESCRIPTION
When the `updated_conversation` event comes in, it could really mean any number of things, but a lot of the time it just means that the snippet was updated. 

It has never been handled in the past, because the `added_message` event has always effectively taken care of the snippet updates. With the new draft support though, that is a bit different. I am doing something a bit different for the draft support, in terms of updating the conversation snippets. I discussed some drawbacks, here: #110. 

With this change and [this change on Android](https://github.com/klinker-apps/pulse-sms-android/commit/f94dfe0b956cead434c8f2d4a67e046d17df04e4), drafts will work in the following way:

* when a draft is saved from the web, it is pushed out to all of the other devices on the user's account
* when the phone app (primary device) picks that up, it will generate the snippet for that draft and apply it to the conversation
* when it is applied to the conversation, that snippet will be updated to the cloud
* at that point, it is pushed out through the websocket and this new listener will pick it up and update it on the web app. 

Drafts will still not fully work with snippets until I release a new version of the Android app