### PR TITLE
Added custom notification abstraction & fixed notifications for firefox

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -343,7 +343,7 @@ export default {
 
         // Request notification permissions if setting is on.
         if (this.$store.state.notifications)
-            Notification.requestPermission();
+            Util.requestNotifications();
 
         // Set toolbar color with materialColorChange animiation
         const toolbar = this.$el.querySelector("#toolbar");

--- a/src/utils/api/stream.js
+++ b/src/utils/api/stream.js
@@ -2,7 +2,7 @@ import router from '@/router/';
 import ReconnectingWebsocket from 'reconnecting-websocket';
 import store from '@/store/';
 import joypixels from 'emoji-toolkit';
-import { Api, Util, Url, Crypto, SessionCache, Platform, i18n } from '@/utils/';
+import { Api, Util, Url, Crypto, Notifications, SessionCache, Platform, i18n } from '@/utils';
 
 export default class Stream {
     constructor() {
@@ -124,7 +124,7 @@ export default class Stream {
                 SessionCache.updateConversationSnippet(id, snippet, 'index_public_unarchived');
                 SessionCache.updateConversationSnippet(id, snippet, 'index_archived');
                 SessionCache.updateConversationSnippet(id, snippet, 'index_private');
-    
+
                 store.state.msgbus.$emit('conversationSnippetUpdated', id, snippet);
             }
         } else if (operation == "update_message_type") {
@@ -165,7 +165,7 @@ export default class Stream {
      * @param message  - message object
      */
     notify(message) {
-        if (Notification.permission != "granted" && !store.state.notifications)
+        if (Notifications.needsPermission() && !store.state.notifications)
             return;
 
         if (message.type != 0)
@@ -187,8 +187,8 @@ export default class Stream {
 
             const link = "/thread/" + message.conversation_id;
 
-            const notification = new Notification(title, {
-                icon: '/static/images/android-desktop.png',
+            const notification = Notifications.notify(title, {
+                icon: require('@/../public/images/android-desktop.png'),
                 body: snippet
             });
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,6 +3,7 @@ import Crypto from '@/utils/crypto.js';
 import Url from '@/utils/url.js';
 import Api from '@/utils/api_manager.js';
 import MediaLoader from '@/utils/media.js';
+import Notifications from '@/utils/notifications.js';
 import SessionCache from '@/utils/cache_manager.js';
 import ShortcutKeys from '@/utils/shortcuts.js';
 import Platform from '@/utils/platform.js';
@@ -15,6 +16,7 @@ export {
     Url,
     Api,
     MediaLoader,
+    Notifications,
     SessionCache,
     ShortcutKeys,
     Platform,

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -1,0 +1,32 @@
+
+export default class Notifications {
+    static getNotification() {
+        const notification = window.Notification;
+        return notification ? notification : {};
+    }
+
+    static needsPermission() {
+        const notification = Notifications.getNotification();
+        return (notification && notification.permission && notification.permission === 'granted') ? false : true;
+    }
+
+    static requestPermission() {
+        return new Promise((reject, resolve) => {
+            if (!Notifications.needsPermission())
+                return resolve();
+
+            // Return promise
+            return Notification.getNotification().requestPermission().then(perm => {
+                if (perm === 'granted')
+                    return resolve();
+                else if (perm === 'denied')
+                    return reject();
+            });
+        });
+    }
+
+    static notify (title, options) {
+        const notification = Notifications.getNotification();
+        return new notification(title, options);
+    }
+}

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -1,6 +1,8 @@
 import jump from 'jump.js';
 import firebase from 'firebase/app';
 import 'firebase/storage';
+import { Notifications } from '@/utils';
+import router from '@/router/';
 import store from '@/store/';
 
 export default class Util {
@@ -195,6 +197,35 @@ export default class Util {
                 i.object.removeEventListener(i.event, i.listener);
             }
         );
+    }
+
+    /**
+     * Requests Notification Permissions
+     * Handles check and error cases
+     */
+    static requestNotifications () {
+
+        // Determine if notification request is necessary
+        if (!store.state.notifications || !Notifications.needsPermission()) {
+            return;
+        }
+
+        // This promise may not ever fire because the notificatino api is bad
+        Notifications.requestPermission().then(() => {
+            // Noop
+        }).catch(() => {
+            // If denied, set setting to false and alert
+            store.commit('notifications', false);
+            Util.snackbar({
+                message: "Noticiations have been disabled",
+                actionHandler: settingsRedirect,
+                actionText: 'Settings'
+            });
+
+            const settingsRedirect = () => router.push('settings').catch(() => {});
+        });
+
+        // Handle redirect to settings page
     }
 
     static firebaseConfig () {


### PR DESCRIPTION
This is a mess... but this should actually fix notification abstraction. Notifyjs simply doesn't work and is NOT a polyfil (it is out of date).

Notifyjs added additional errors on electron & other non-standard browsers. It also broke event handling completely. 
It did however bring to light issues with firefox notifications not working. This has been fixed.

This provides a basic polyfill and renables notification support fo firefox.

This does NOT fix issues with the samsung notification api relating to service workers: `Notification': Illegal constructor. Use ServiceWorkerRegistration.showNotification() `