### PR TITLE
Fix/notifications

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -342,7 +342,8 @@ export default {
         this.$store.state.msgbus.$on('currentlySelectedConversations', this.updateSelectedConversations);
 
         // Request notification permissions if setting is on.
-        Util.requestNotifications();
+        if (this.$store.state.notifications)
+            Util.requestNotifications();
 
         // Set toolbar color with materialColorChange animiation
         const toolbar = this.$el.querySelector("#toolbar");

--- a/src/utils/api/stream.js
+++ b/src/utils/api/stream.js
@@ -2,7 +2,7 @@ import ReconnectingWebsocket from 'reconnecting-websocket';
 import joypixels from 'emoji-toolkit';
 import router from '@/router/';
 import store from '@/store/';
-import { Api, Util, Url, Crypto, Notifications, SessionCache, Platform, i18n } from '@/utils/';
+import { Api, Util, Url, Crypto, Notifications, SessionCache, Platform, i18n } from '@/utils';
 
 export default class Stream {
     constructor() {

--- a/src/utils/api/stream.js
+++ b/src/utils/api/stream.js
@@ -1,9 +1,8 @@
 import ReconnectingWebsocket from 'reconnecting-websocket';
 import joypixels from 'emoji-toolkit';
-import Notify from 'notifyjs';
 import router from '@/router/';
 import store from '@/store/';
-import { Api, Util, Url, Crypto, SessionCache, Platform, i18n } from '@/utils/';
+import { Api, Util, Url, Crypto, Notifications, SessionCache, Platform, i18n } from '@/utils/';
 
 export default class Stream {
     constructor() {
@@ -166,7 +165,7 @@ export default class Stream {
      * @param message  - message object
      */
     notify(message) {
-        if (Notify.needsPermission && !store.state.notifications)
+        if (Notifications.needsPermission() && !store.state.notifications)
             return;
 
         if (message.type != 0)
@@ -188,18 +187,15 @@ export default class Stream {
 
             const link = "/thread/" + message.conversation_id;
 
-            const onclick = () => {
+            const notification = Notifications.notify(title, {
+                icon: require('@/../public/images/android-desktop.png'),
+                body: snippet
+            });
+
+            notification.onclick = () => {
                 window.focus();
                 router.push(link).catch(() => {});
             };
-
-            const notification = new Notify(title, {
-                icon: require('@/../public/images/android-desktop.png'), // Require to resolve
-                body: snippet,
-                notifyClick: onclick
-            });
-
-            notification.show();
         });
     }
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,6 +3,7 @@ import Crypto from '@/utils/crypto.js';
 import Url from '@/utils/url.js';
 import Api from '@/utils/api_manager.js';
 import MediaLoader from '@/utils/media.js';
+import Notifications from '@/utils/notifications.js';
 import SessionCache from '@/utils/cache_manager.js';
 import ShortcutKeys from '@/utils/shortcuts.js';
 import Platform from '@/utils/platform.js';
@@ -15,6 +16,7 @@ export {
     Url,
     Api,
     MediaLoader,
+    Notifications,
     SessionCache,
     ShortcutKeys,
     Platform,

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -1,0 +1,34 @@
+
+export default class Notifications {
+    static getNotification() {
+        const notification = window.Notification;
+        return notification ? notification : {};
+    }
+
+    static needsPermission() {
+        const notification = Notifications.getNotification();
+        return (notification && notification.permission && notification.permission === 'granted') ? false : true;
+    }
+
+    static requestPermission() {
+        return new Promise((resolve, reject) => {
+            console.log(Notifications.needsPermission());
+            if (!Notifications.needsPermission())
+                return resolve();
+
+            // Return promise
+            return Notifications.getNotification().requestPermission().then(perm => {
+                console.log(perm);
+                if (perm === 'granted')
+                    return resolve();
+                else if (perm === 'denied')
+                    return reject();
+            });
+        });
+    }
+
+    static notify (title, options) {
+        const notification = Notifications.getNotification();
+        return new notification(title, options);
+    }
+}

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -12,13 +12,11 @@ export default class Notifications {
 
     static requestPermission() {
         return new Promise((resolve, reject) => {
-            console.log(Notifications.needsPermission());
             if (!Notifications.needsPermission())
                 return resolve();
 
             // Return promise
             return Notifications.getNotification().requestPermission().then(perm => {
-                console.log(perm);
                 if (perm === 'granted')
                     return resolve();
                 else if (perm === 'denied')

--- a/src/utils/platform.js
+++ b/src/utils/platform.js
@@ -17,6 +17,10 @@ export default class Platform {
         return !Platform.isChromeExtension() && !Platform.isChromeApp() && !Platform.isNativeDesktop();
     }
 
+    static isFirefox () {
+        return navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+    }
+
     static getPlatformIdentifier() {
         if (Platform.isChromeExtension()) {
             return 1;

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -1,7 +1,7 @@
 import jump from 'jump.js';
 import firebase from 'firebase/app';
 import 'firebase/storage';
-import Notify from 'notifyjs';
+import { Notifications } from '@/utils';
 import store from '@/store/';
 import router from '@/router/';
 
@@ -147,37 +147,6 @@ export default class Util {
     }
 
     /**
-     * Requests Notification Permissions
-     * Handles check and error cases
-     */
-    static requestNotifications () {
-
-        // Check if oermission needs to be granted
-        if (!Notify.needsPermission) {
-            return;
-        }
-
-        // Request notification permissions if setting is on.
-        if (store.state.notifications && Notify.isSupported()) {
-            Notify.requestPermission(() => {}, notificationsDenied);
-        }
-
-        const notificationsDenied = () => {
-
-            // If denied, set setting to false and alert
-            store.commit('notifications', false);
-            Util.snackbar({
-                message: "Noticiations have been disabled",
-                actionHandler: settingsRedirect,
-                actionText: 'Settings'
-            });
-        };
-
-        // Handle redirect to settings page
-        const settingsRedirect = () => router.push('settings').catch(() => {});
-    }
-
-    /**
      * Display an image in the full screen viewer
      */
     static displayImage(mediaLoader, messageId, type) {
@@ -228,6 +197,36 @@ export default class Util {
                 i.object.removeEventListener(i.event, i.listener);
             }
         );
+    }
+
+    /**
+     * Requests Notification Permissions
+     * Handles check and error cases
+     */
+    static requestNotifications () {
+
+        // Determine if notification request is necessary
+        if (!store.state.notifications || !Notifications.needsPermission()) {
+            return;
+        }
+
+        // This promise may not ever fire because the notificatino api is bad
+        Notifications.requestPermission().then(() => {
+            // Noop
+        }).catch(() => {
+            console.log("disabling");
+            // If denied, set setting to false and alert
+            store.commit('notifications', false);
+            Util.snackbar({
+                message: "Noticiations have been disabled",
+                actionHandler: settingsRedirect,
+                actionText: 'Settings'
+            });
+
+            const settingsRedirect = () => router.push('settings').catch(() => {});
+        });
+
+        // Handle redirect to settings page
     }
 
     static firebaseConfig () {

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -214,7 +214,8 @@ export default class Util {
         Notifications.requestPermission().then(() => {
             // Noop
         }).catch(() => {
-            console.log("disabling");
+            const settingsRedirect = () => router.push('settings').catch(() => {});
+
             // If denied, set setting to false and alert
             store.commit('notifications', false);
             Util.snackbar({
@@ -222,8 +223,6 @@ export default class Util {
                 actionHandler: settingsRedirect,
                 actionText: 'Settings'
             });
-
-            const settingsRedirect = () => router.push('settings').catch(() => {});
         });
 
         // Handle redirect to settings page


### PR DESCRIPTION
This is a mess... but this should actually fix notification abstraction. Notifyjs simply doesn't work and is NOT a polyfill (it is out of date).

Notifyjs added additional errors on electron & other non-standard browsers. It also broke event handling completely. 
It did, however, bring to light issues with firefox notifications not working. This has been fixed.

This provides a basic polyfill and renables notification support fo firefox.

This does NOT fix issues with the samsung notification api relating to service workers: `Notification': Illegal constructor. Use ServiceWorkerRegistration.showNotification() `