### PR TITLE
Fix unread count...

### DIFF
--- a/src/mixins/unreadCountMixin.js
+++ b/src/mixins/unreadCountMixin.js
@@ -1,0 +1,11 @@
+import store from '@/store';
+
+export default {
+    methods: {
+        updateUnreadCount () {
+            const conversations = store.state.session_conversations.index_public_unarchived;
+            const newUnreadCount = conversations.reduce((count, conv) => count + (conv.read ? 0 : 1), 0);
+            store.commit('unread_count', newUnreadCount);
+        },
+    },
+};

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -93,8 +93,6 @@ export const mutations = {
     loading: (state, loading) => state.loading = loading,
     hotkey_navigation: (state, hotkey_navigation) => state.hotkey_navigation = hotkey_navigation,
     unread_count: (state, unread_count) => state.unread_count = unread_count,
-    increment_unread_count: (state) => state.unread_count++,
-    decrement_unread_count: (state) => state.unread_count--,
     full_theme: (state, full_theme) => state.full_theme = full_theme,
     sidebar_open: (state, sidebar_open) => state.sidebar_open = sidebar_open,
     account_id: (state, account_id) => state.account_id = account_id,

--- a/src/utils/cache_manager.js
+++ b/src/utils/cache_manager.js
@@ -68,7 +68,7 @@ export default class SessionCache {
 
     static putMessages (messages, conversation_id) {
         let sessionMessages = SessionCache.getAllMessages();
-        sessionMessages[conversation_id] = messages;
+        sessionMessages[conversation_id] = JSON.parse(JSON.stringify(messages));
 
         store.commit('session_messages', sessionMessages);
     }
@@ -225,6 +225,7 @@ export default class SessionCache {
         if (conversations != null) {
             for (let i = 0; i < conversations.length; i++) {
                 if (conversations[i].device_id == message.conversation_id) {
+                    conversations[i].read = message.read;
                     conversations[i].timestamp = message.timestamp;
                     conversations[i].snippet = message.mime_type.indexOf("text") > -1 ? message.data : "";
                     this.putConversations(this.resortConversations(conversations), 'index_public_unarchived');
@@ -237,6 +238,7 @@ export default class SessionCache {
         if (conversations != null) {
             for (let i = 0; i < conversations.length; i++) {
                 if (conversations[i].device_id == message.conversation_id) {
+                    conversations[i].read = message.read;
                     conversations[i].timestamp = message.timestamp;
                     conversations[i].snippet = message.mime_type.indexOf("text") > -1 ? message.data : "";
                     this.putConversations(this.resortConversations(conversations), 'index_archived');
@@ -249,6 +251,7 @@ export default class SessionCache {
         if (conversations != null) {
             for (let i = 0; i < conversations.length; i++) {
                 if (conversations[i].device_id == message.conversation_id) {
+                    conversations[i].read = message.read;
                     conversations[i].timestamp = message.timestamp;
                     conversations[i].snippet = message.mime_type.indexOf("text") > -1 ? message.data : "";
                     this.putConversations(this.resortConversations(conversations), 'index_private');


### PR DESCRIPTION
This should fix unread count for a final time.

Attempting to count incoming notifications is stupid. This creates a mixin to reduce on session cache and save that value to state. 

It seems to be more accurate and hold to the one and only edge case: multiple notifications on the same thread occur in succession.